### PR TITLE
Provision for parameters in dependent implementation

### DIFF
--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -42,7 +42,7 @@ class SwiftAdapter extends AbstractAdapter
     {
         $path = $this->applyPathPrefix($path);
 
-        $data = $this->getData($path);
+        $data = $this->getWriteData($path);
         $type = 'content';
 
         if (is_a($contents, 'GuzzleHttp\Psr7\Stream')) {
@@ -254,13 +254,13 @@ class SwiftAdapter extends AbstractAdapter
     }
 
     /**
-     * Get data properties of object
+     * Get the data properties to write or update an object.
      *
      * @param string $path
      *
      * @return array
      */
-    protected function getData($path)
+    protected function getWriteData($path)
     {
         return ['name' => $path];
     }

--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -42,7 +42,7 @@ class SwiftAdapter extends AbstractAdapter
     {
         $path = $this->applyPathPrefix($path);
 
-        $data = ['name' => $path];
+        $data = $this->getData($path);
         $type = 'content';
 
         if (is_a($contents, 'GuzzleHttp\Psr7\Stream')) {
@@ -251,6 +251,18 @@ class SwiftAdapter extends AbstractAdapter
     public function getTimestamp($path)
     {
         return $this->getMetadata($path);
+    }
+
+    /**
+     * Get data properties of object
+     *
+     * @param string $path
+     *
+     * @return array
+     */
+    protected function getData($path)
+    {
+        return ['name' => $path];
     }
 
     /**


### PR DESCRIPTION
The current implementation does not allow for more parameters to be added to the object being upload (for eg, `deleteAfter`, `deleteAt` etc). See additional parameters [here](https://github.com/php-opencloud/openstack/blob/master/src/ObjectStore/v1/Params.php)

By having a method in the adapter, any dependent implementation (like [my package](https://github.com/sausin/laravel-ovh/)) can add these additional parameters, if required, by overriding the new `getData` method without having to change the base implementation of `write`, or `writeStream` methods